### PR TITLE
Character Sheet: Gold +/- buttons are odd on windoze

### DIFF
--- a/src/uk/co/dezzanet/gametable/charactersheet/CharacterSheetPanel.java
+++ b/src/uk/co/dezzanet/gametable/charactersheet/CharacterSheetPanel.java
@@ -93,7 +93,7 @@ public class CharacterSheetPanel extends JPanel implements ICharacterDataChanged
 		Dimension gold_size = gold.getPreferredSize();
 		gold_size.width = 70;
 		gold.setPreferredSize(gold_size);
-		add(gold); 
+		add(gold);
 		
 		Dimension button_size = new Dimension();
 		button_size.setSize(30, gold_size.getHeight());


### PR DESCRIPTION
Will need to look at setting explicit dimensions rather than calculating from other fields.
