### PR TITLE
host will now add pog packet on copy instead of sending to clients

### DIFF
--- a/src/com/galactanet/gametable/GametableFrame.java
+++ b/src/com/galactanet/gametable/GametableFrame.java
@@ -743,9 +743,14 @@ public class GametableFrame extends JFrame implements ActionListener
         final boolean priv = !(getGametableCanvas().isPublicMap());
         
         nPog.setId(-1);
-        if ((m_netStatus == NETSTATE_NONE) || priv)  {
+        if (m_netStatus == NETSTATE_NONE 
+         || m_netStatus == NETSTATE_HOST // The host always sends to all clients when it receives a packet 
+         || priv)
+        {
             addPogPacketReceived(nPog, !priv);
-        } else {
+        }
+        else
+        {
             send(PacketManager.makeAddPogPacket(nPog));
         }
     }


### PR DESCRIPTION
Previously it would just send it to clients and not itself. When it
receives a pog packet from a client it sends it to all clients anyway so
just receiving it will automatically send it to clients
