### PR TITLE
Register CharacterSheetPlugin as a LeftPanelProvider

### DIFF
--- a/src/com/galactanet/gametable/GametableFrame.java
+++ b/src/com/galactanet/gametable/GametableFrame.java
@@ -403,6 +403,7 @@ public class GametableFrame extends JFrame implements ActionListener
     private List<IGametablePlugin> plugins = new ArrayList<>();
     private List<IAutoSaveListener> autoSaveListeners = new ArrayList<>();
     private EventDispatcher eventDispatcher = new EventDispatcher();
+    private List<ILeftPanel> leftPanelProviders = new ArrayList<>();
 
     /**
      * Construct the frame
@@ -5160,6 +5161,10 @@ public class GametableFrame extends JFrame implements ActionListener
 
     public void registerAutoSaveListener(IAutoSaveListener listener) {
         autoSaveListeners.add(listener);
+    }
+
+    public void registerLeftPanelProvider(ILeftPanel panelProvider) {
+        leftPanelProviders.add(panelProvider);
     }
 
     public EventDispatcher getEventDispatcher() {

--- a/src/com/galactanet/gametable/GametableFrame.java
+++ b/src/com/galactanet/gametable/GametableFrame.java
@@ -403,7 +403,7 @@ public class GametableFrame extends JFrame implements ActionListener
     private List<IGametablePlugin> plugins = new ArrayList<>();
     private List<IAutoSaveListener> autoSaveListeners = new ArrayList<>();
     private EventDispatcher eventDispatcher = new EventDispatcher();
-    private List<ILeftPanel> leftPanelProviders = new ArrayList<>();
+    private List<ILeftPanelProvider> leftPanelProviders = new ArrayList<>();
 
     /**
      * Construct the frame
@@ -5163,7 +5163,7 @@ public class GametableFrame extends JFrame implements ActionListener
         autoSaveListeners.add(listener);
     }
 
-    public void registerLeftPanelProvider(ILeftPanel panelProvider) {
+    public void registerLeftPanelProvider(ILeftPanelProvider panelProvider) {
         leftPanelProviders.add(panelProvider);
     }
 

--- a/src/com/galactanet/gametable/GametableFrame.java
+++ b/src/com/galactanet/gametable/GametableFrame.java
@@ -5153,7 +5153,7 @@ public class GametableFrame extends JFrame implements ActionListener
         }
     }
 
-    public void addPanelToLeftPane(JPanel panel, String title)
+    private void addPanelToLeftPane(JPanel panel, String title)
     {
         m_pogsTabbedPane.add(panel, title);
     }

--- a/src/com/galactanet/gametable/GametableFrame.java
+++ b/src/com/galactanet/gametable/GametableFrame.java
@@ -3232,6 +3232,9 @@ public class GametableFrame extends JFrame implements ActionListener
         addPanelToLeftPane(m_pogPanel, lang.POG_LIBRARY);
         addPanelToLeftPane(m_activePogsPanel, lang.POG_ACTIVE);
         addPanelToLeftPane(m_macroPanel, lang.DICE_MACROS);
+        for (ILeftPanelProvider panelProvider : leftPanelProviders) {
+            addPanelToLeftPane(panelProvider.getLeftPanel(), panelProvider.getPanelTitle());
+        }
     }
 
     /**

--- a/src/com/galactanet/gametable/ILeftPanel.java
+++ b/src/com/galactanet/gametable/ILeftPanel.java
@@ -1,0 +1,7 @@
+package com.galactanet.gametable;
+
+import javax.swing.*;
+
+public interface ILeftPanel {
+    JPanel getLeftPanel();
+}

--- a/src/com/galactanet/gametable/ILeftPanelProvider.java
+++ b/src/com/galactanet/gametable/ILeftPanelProvider.java
@@ -2,6 +2,7 @@ package com.galactanet.gametable;
 
 import javax.swing.*;
 
-public interface ILeftPanel {
+public interface ILeftPanelProvider {
     JPanel getLeftPanel();
+    String getPanelTitle();
 }

--- a/src/uk/co/dezzanet/gametable/charactersheet/CharacterSheetPlugin.java
+++ b/src/uk/co/dezzanet/gametable/charactersheet/CharacterSheetPlugin.java
@@ -10,11 +10,10 @@ public class CharacterSheetPlugin implements IGametablePlugin, ILeftPanel {
 
     private static final String PLUGIN_NAME = "Character sheet";
     private static final String PANEL_TITLE = "Character Sheet";
-    private CharacterSheetPanel panel;
+    private CharacterSheetPanel panel = new CharacterSheetPanel();
 
     @Override
     public void initialise(GametableFrame gametable) {
-        panel = new CharacterSheetPanel();
         gametable.addPanelToLeftPane(panel, PANEL_TITLE);
         gametable.registerAutoSaveListener(new AutoSaveListener(panel.getStorage()));
         gametable.getEventDispatcher().listenForPogMenuRender(new PogMenuRenderListener(panel.getPogAdapter()));

--- a/src/uk/co/dezzanet/gametable/charactersheet/CharacterSheetPlugin.java
+++ b/src/uk/co/dezzanet/gametable/charactersheet/CharacterSheetPlugin.java
@@ -2,15 +2,19 @@ package uk.co.dezzanet.gametable.charactersheet;
 
 import com.galactanet.gametable.GametableFrame;
 import com.galactanet.gametable.IGametablePlugin;
+import com.galactanet.gametable.ILeftPanel;
 
-public class CharacterSheetPlugin implements IGametablePlugin {
+import javax.swing.*;
+
+public class CharacterSheetPlugin implements IGametablePlugin, ILeftPanel {
 
     private static final String PLUGIN_NAME = "Character sheet";
     private static final String PANEL_TITLE = "Character Sheet";
+    private CharacterSheetPanel panel;
 
     @Override
     public void initialise(GametableFrame gametable) {
-        CharacterSheetPanel panel = new CharacterSheetPanel();
+        panel = new CharacterSheetPanel();
         gametable.addPanelToLeftPane(panel, PANEL_TITLE);
         gametable.registerAutoSaveListener(new AutoSaveListener(panel.getStorage()));
         gametable.getEventDispatcher().listenForPogMenuRender(new PogMenuRenderListener(panel.getPogAdapter()));
@@ -19,5 +23,10 @@ public class CharacterSheetPlugin implements IGametablePlugin {
     @Override
     public String getName() {
         return PLUGIN_NAME;
+    }
+
+    @Override
+    public JPanel getLeftPanel() {
+        return panel;
     }
 }

--- a/src/uk/co/dezzanet/gametable/charactersheet/CharacterSheetPlugin.java
+++ b/src/uk/co/dezzanet/gametable/charactersheet/CharacterSheetPlugin.java
@@ -2,11 +2,11 @@ package uk.co.dezzanet.gametable.charactersheet;
 
 import com.galactanet.gametable.GametableFrame;
 import com.galactanet.gametable.IGametablePlugin;
-import com.galactanet.gametable.ILeftPanel;
+import com.galactanet.gametable.ILeftPanelProvider;
 
 import javax.swing.*;
 
-public class CharacterSheetPlugin implements IGametablePlugin, ILeftPanel {
+public class CharacterSheetPlugin implements IGametablePlugin, ILeftPanelProvider {
 
     private static final String PLUGIN_NAME = "Character sheet";
     private static final String PANEL_TITLE = "Character Sheet";
@@ -27,5 +27,10 @@ public class CharacterSheetPlugin implements IGametablePlugin, ILeftPanel {
     @Override
     public JPanel getLeftPanel() {
         return panel;
+    }
+
+    @Override
+    public String getPanelTitle() {
+        return PANEL_TITLE;
     }
 }

--- a/src/uk/co/dezzanet/gametable/charactersheet/CharacterSheetPlugin.java
+++ b/src/uk/co/dezzanet/gametable/charactersheet/CharacterSheetPlugin.java
@@ -14,7 +14,7 @@ public class CharacterSheetPlugin implements IGametablePlugin, ILeftPanel {
 
     @Override
     public void initialise(GametableFrame gametable) {
-        gametable.addPanelToLeftPane(panel, PANEL_TITLE);
+        gametable.registerLeftPanelProvider(this);
         gametable.registerAutoSaveListener(new AutoSaveListener(panel.getStorage()));
         gametable.getEventDispatcher().listenForPogMenuRender(new PogMenuRenderListener(panel.getPogAdapter()));
     }

--- a/src/uk/co/dezzanet/gametable/charactersheet/CharacterSheetPlugin.java
+++ b/src/uk/co/dezzanet/gametable/charactersheet/CharacterSheetPlugin.java
@@ -10,10 +10,11 @@ public class CharacterSheetPlugin implements IGametablePlugin, ILeftPanelProvide
 
     private static final String PLUGIN_NAME = "Character sheet";
     private static final String PANEL_TITLE = "Character Sheet";
-    private CharacterSheetPanel panel = new CharacterSheetPanel();
+    private CharacterSheetPanel panel;
 
     @Override
     public void initialise(GametableFrame gametable) {
+        panel = getCharacterSheetPanel();
         gametable.registerLeftPanelProvider(this);
         gametable.registerAutoSaveListener(new AutoSaveListener(panel.getStorage()));
         gametable.getEventDispatcher().listenForPogMenuRender(new PogMenuRenderListener(panel.getPogAdapter()));
@@ -26,11 +27,18 @@ public class CharacterSheetPlugin implements IGametablePlugin, ILeftPanelProvide
 
     @Override
     public JPanel getLeftPanel() {
-        return panel;
+        return getCharacterSheetPanel();
     }
 
     @Override
     public String getPanelTitle() {
         return PANEL_TITLE;
+    }
+
+    private CharacterSheetPanel getCharacterSheetPanel() {
+        if (panel == null) {
+            panel = new CharacterSheetPanel();
+        }
+        return panel;
     }
 }


### PR DESCRIPTION
A couple of tweaks to core and the char sheet plugin to allow the plugin to register as a left panel provider and then have it rendered when `gameTableFrame` wants to render it.